### PR TITLE
Add HPKE Context and related context export methods

### DIFF
--- a/hybrid_pke_test.py
+++ b/hybrid_pke_test.py
@@ -31,8 +31,8 @@ class TestHpke(parameterized.TestCase):
         info = b""
         aad = b""
         encap, ctxt = hpke.seal(pkR, info, aad, ptxt)
-        ptxt_roundtrip = hpke.open(encap, skR, info, aad, ctxt)
-        assert ptxt == ptxt_roundtrip
+        ptxt_onetrip = hpke.open(encap, skR, info, aad, ctxt)
+        assert ptxt == ptxt_onetrip
 
     @parameterized.parameters(
         hybrid_pke.Kem.DHKEM_P384,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,61 @@
+use hpke_rs::Context as ContextRs;
+use hpke_rs_rust_crypto::HpkeRustCrypto;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use crate::errors::*;
+
+pub(crate) type Context = ContextRs<HpkeRustCrypto>;
+
+#[pyclass]
+#[pyo3(name = "Context", module = "hybrid_pke")]
+pub(crate) struct PyContext {
+    ctx: Context,
+}
+
+impl PyContext {
+    pub(crate) fn new(ctx: Context) -> Self {
+        PyContext { ctx }
+    }
+}
+
+#[pymethods]
+impl PyContext {
+    fn seal<'p>(
+        &mut self,
+        py: Python<'p>,
+        aad: &PyBytes,
+        plain_txt: &PyBytes,
+    ) -> PyResult<&'p PyBytes> {
+        let aad = aad.as_bytes();
+        let plain_txt = plain_txt.as_bytes();
+        let cipher_txt = self.ctx.seal(aad, plain_txt).map_err(handle_hpke_error)?;
+        Ok(PyBytes::new(py, cipher_txt.as_slice()))
+    }
+
+    fn open<'p>(
+        &mut self,
+        py: Python<'p>,
+        aad: &PyBytes,
+        cipher_txt: &PyBytes,
+    ) -> PyResult<&'p PyBytes> {
+        let aad = aad.as_bytes();
+        let cipher_txt = cipher_txt.as_bytes();
+        let plain_txt = self.ctx.open(aad, cipher_txt).map_err(handle_hpke_error)?;
+        Ok(PyBytes::new(py, plain_txt.as_slice()))
+    }
+
+    fn export<'p>(
+        &self,
+        py: Python<'p>,
+        exporter_context: &PyBytes,
+        length: usize,
+    ) -> PyResult<&'p PyBytes> {
+        let exporter_context = exporter_context.as_bytes();
+        let exporter_secret = self
+            .ctx
+            .export(exporter_context, length)
+            .map_err(handle_hpke_error)?;
+        Ok(PyBytes::new(py, exporter_secret.as_slice()))
+    }
+}

--- a/src/hpke.rs
+++ b/src/hpke.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
 use crate::config::*;
+use crate::context::PyContext;
 use crate::errors::*;
 
 pub(crate) type Hpke = HpkeRs<HpkeRustCrypto>;
@@ -42,17 +43,73 @@ impl PyHpke {
         }
     }
 
-    /// Generate a key-pair according to this Hpke config
-    fn generate_key_pair<'p>(&self, py: Python<'p>) -> PyResult<(&'p PyBytes, &'p PyBytes)> {
+    /// Set up an HPKE sender context
+    #[args(psk = "None", psk_id = "None", sk_s = "None")]
+    fn setup_sender<'p>(
+        &self,
+        py: Python<'p>,
+        pk_r: &PyBytes,
+        info: &PyBytes,
+        psk: Option<&PyBytes>,
+        psk_id: Option<&PyBytes>,
+        sk_s: Option<&PyBytes>,
+    ) -> PyResult<(&'p PyBytes, PyContext)> {
         let cfg: Hpke = self.into();
-        let keypair = cfg.generate_key_pair().map_err(handle_hpke_error)?;
-        let (sk, pk) = keypair.into_keys();
-        let sk_py = PyBytes::new(py, sk.as_slice());
-        let pk_py = PyBytes::new(py, pk.as_slice());
-        Ok((sk_py, pk_py))
+
+        // convert args, drop py refs
+        let pk_r = HpkePublicKey::new(pk_r.as_bytes().into());
+        let info = info.as_bytes();
+        let psk = psk.map(|x| x.as_bytes());
+        let psk_id = psk_id.map(|x| x.as_bytes());
+
+        // create sender context
+        let (encap, context) = match sk_s {
+            None => cfg.setup_sender(&pk_r, info, psk, psk_id, None),
+            Some(sk) => {
+                let sk = HpkePrivateKey::new(sk.as_bytes().into());
+                cfg.setup_sender(&pk_r, info, psk, psk_id, Some(&sk))
+            }
+        }
+        .map_err(handle_hpke_error)?;
+        let encap_py = PyBytes::new(py, encap.as_slice());
+        let context_py = PyContext::new(context);
+        Ok((encap_py, context_py))
     }
 
-    /// Use this Hpke config for single-shot encryption
+    /// Set up an HPKE receiver context
+    #[args(psk = "None", psk_id = "None", pk_s = "None")]
+    fn setup_receiver(
+        &self,
+        enc: &PyBytes,
+        sk_r: &PyBytes,
+        info: &PyBytes,
+        psk: Option<&PyBytes>,
+        psk_id: Option<&PyBytes>,
+        pk_s: Option<&PyBytes>,
+    ) -> PyResult<PyContext> {
+        let cfg: Hpke = self.into();
+
+        // convert args, drop py refs
+        let enc = enc.as_bytes();
+        let sk_r = HpkePrivateKey::new(sk_r.as_bytes().into());
+        let info = info.as_bytes();
+        let psk = psk.map(|x| x.as_bytes());
+        let psk_id = psk_id.map(|x| x.as_bytes());
+
+        // create receiver context
+        let context = match pk_s {
+            None => cfg.setup_receiver(enc, &sk_r, info, psk, psk_id, None),
+            Some(pk) => {
+                let pk = HpkePublicKey::new(pk.as_bytes().into());
+                cfg.setup_receiver(enc, &sk_r, info, psk, psk_id, Some(&pk))
+            }
+        }
+        .map_err(handle_hpke_error)?;
+
+        Ok(PyContext::new(context))
+    }
+
+    /// Encrypt input, single-shot
     #[allow(clippy::too_many_arguments)]
     #[args(psk = "None", psk_id = "None", sk_s = "None")]
     fn seal<'p>(
@@ -68,7 +125,7 @@ impl PyHpke {
     ) -> PyResult<(&'p PyBytes, &'p PyBytes)> {
         let cfg: Hpke = self.into();
 
-        // convert all args and drop py refs immediately
+        // convert args, drop py refs
         let pk_r = HpkePublicKey::new(pk_r.as_bytes().into());
         let info = info.as_bytes();
         let aad = aad.as_bytes();
@@ -95,7 +152,7 @@ impl PyHpke {
         Ok((encap_py, cipher_txt_py))
     }
 
-    /// Use this Hpke config for single-shot decryption
+    /// Decrypt input, single-shot
     #[allow(clippy::too_many_arguments)]
     #[args(psk = "None", psk_id = "None", pk_s = "None")]
     fn open<'p>(
@@ -112,7 +169,7 @@ impl PyHpke {
     ) -> PyResult<&'p PyBytes> {
         let cfg: Hpke = self.into();
 
-        // convert all args and drop py refs immediately
+        // convert args, drop py refs
         let enc = enc.as_bytes();
         let sk_r = HpkePrivateKey::new(sk_r.as_bytes().into());
         let info = info.as_bytes();

--- a/src/hpke.rs
+++ b/src/hpke.rs
@@ -190,8 +190,154 @@ impl PyHpke {
         .map_err(handle_hpke_error)?;
 
         // convert return val back to PyBytes
-        let plain_txt_py = PyBytes::new(py, plain_txt.as_slice());
-        Ok(plain_txt_py)
+        Ok(PyBytes::new(py, plain_txt.as_slice()))
+    }
+
+    /// Derive an exporter secret for sender with public key `pk_r`, single-shot
+    #[allow(clippy::too_many_arguments)]
+    #[args(psk = "None", psk_id = "None", sk_s = "None")]
+    fn send_export<'p>(
+        &self,
+        py: Python<'p>,
+        pk_r: &PyBytes,
+        info: &PyBytes,
+        exporter_context: &PyBytes,
+        length: usize,
+        psk: Option<&PyBytes>,
+        psk_id: Option<&PyBytes>,
+        sk_s: Option<&PyBytes>,
+    ) -> PyResult<(&'p PyBytes, &'p PyBytes)> {
+        let cfg: Hpke = self.into();
+
+        // convert args, drop py refs
+        let pk_r = HpkePublicKey::new(pk_r.as_bytes().into());
+        let info = info.as_bytes();
+        let psk = psk.map(|x| x.as_bytes());
+        let psk_id = psk_id.map(|x| x.as_bytes());
+        let exporter_context = exporter_context.as_bytes();
+
+        // derive sender export secret
+        let (encap, exporter_secret) = match sk_s {
+            None => cfg.send_export(&pk_r, info, psk, psk_id, None, exporter_context, length),
+            Some(sk) => {
+                let sk = HpkePrivateKey::new(sk.as_bytes().into());
+                cfg.send_export(
+                    &pk_r,
+                    info,
+                    psk,
+                    psk_id,
+                    Some(&sk),
+                    exporter_context,
+                    length,
+                )
+            }
+        }
+        .map_err(handle_hpke_error)?;
+
+        // convert return vals back to PyBytes
+        let encap_py = PyBytes::new(py, encap.as_slice());
+        let exporter_secret_py = PyBytes::new(py, exporter_secret.as_slice());
+        Ok((encap_py, exporter_secret_py))
+    }
+
+    /// Derive an exporter secret for receiver with private key `sk_r`, single-shot
+    #[allow(clippy::too_many_arguments)]
+    #[args(psk = "None", psk_id = "None", pk_s = "None")]
+    fn receiver_export<'p>(
+        &self,
+        py: Python<'p>,
+        enc: &PyBytes,
+        sk_r: &PyBytes,
+        info: &PyBytes,
+        exporter_context: &PyBytes,
+        length: usize,
+        psk: Option<&PyBytes>,
+        psk_id: Option<&PyBytes>,
+        pk_s: Option<&PyBytes>,
+    ) -> PyResult<&'p PyBytes> {
+        let cfg: Hpke = self.into();
+
+        // convert all args and drop py refs immediately
+        let enc = enc.as_bytes();
+        let sk_r = HpkePrivateKey::new(sk_r.as_bytes().into());
+        let info = info.as_bytes();
+        let exporter_context = exporter_context.as_bytes();
+        let psk = psk.map(|x| x.as_bytes());
+        let psk_id = psk_id.map(|x| x.as_bytes());
+
+        // derive receiver export secret
+        let exporter_secret = match pk_s {
+            None => cfg.receiver_export(
+                enc,
+                &sk_r,
+                info,
+                psk,
+                psk_id,
+                None,
+                exporter_context,
+                length,
+            ),
+            Some(pk) => {
+                let pk = HpkePublicKey::new(pk.as_bytes().into());
+                cfg.receiver_export(
+                    enc,
+                    &sk_r,
+                    info,
+                    psk,
+                    psk_id,
+                    Some(&pk),
+                    exporter_context,
+                    length,
+                )
+            }
+        }
+        .map_err(handle_hpke_error)?;
+
+        Ok(PyBytes::new(py, exporter_secret.as_slice()))
+    }
+
+    /// Create an encryption context from a shared secret
+    fn key_schedule(
+        &self,
+        shared_secret: &PyBytes,
+        info: &PyBytes,
+        psk: &PyBytes,
+        psk_id: &PyBytes,
+    ) -> PyResult<PyContext> {
+        let cfg: Hpke = self.into();
+        let shared_secret = shared_secret.as_bytes();
+        let info = info.as_bytes();
+        let psk = psk.as_bytes();
+        let psk_id = psk_id.as_bytes();
+        let context = cfg
+            .key_schedule(shared_secret, info, psk, psk_id)
+            .map_err(handle_hpke_error)?;
+        Ok(PyContext::new(context))
+    }
+
+    /// Generate a key-pair according to the KemAlgorithm in this Hpke config
+    fn generate_key_pair<'p>(&self, py: Python<'p>) -> PyResult<(&'p PyBytes, &'p PyBytes)> {
+        let cfg: Hpke = self.into();
+        let keypair = cfg.generate_key_pair().map_err(handle_hpke_error)?;
+        let (sk, pk) = keypair.into_keys();
+        let sk_py = PyBytes::new(py, sk.as_slice());
+        let pk_py = PyBytes::new(py, pk.as_slice());
+        Ok((sk_py, pk_py))
+    }
+
+    /// Derive a key-pair from given randomness according to the KemAlgorithm in this Hpke config
+    fn derive_key_pair<'p>(
+        &self,
+        py: Python<'p>,
+        ikm: &PyBytes,
+    ) -> PyResult<(&'p PyBytes, &'p PyBytes)> {
+        let cfg: Hpke = self.into();
+        let ikm = ikm.as_bytes();
+        let keypair = cfg.derive_key_pair(ikm).map_err(handle_hpke_error)?;
+        let (sk, pk) = keypair.into_keys();
+        let sk_py = PyBytes::new(py, sk.as_slice());
+        let pk_py = PyBytes::new(py, pk.as_slice());
+        Ok((sk_py, pk_py))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ use pyo3::prelude::*;
 // use rand::{rngs::OsRng, RngCore};
 
 mod config;
+mod context;
 mod errors;
 mod hpke;
 use crate::config::*;
+use crate::context::PyContext;
 use crate::errors::*;
 use crate::hpke::*;
 
@@ -44,6 +46,7 @@ fn hybrid_pke(py: Python, m: &PyModule) -> PyResult<()> {
     let errors_module = build_errors_module(py)?;
     m.add_submodule(errors_module)?;
     m.add_class::<PyHpke>()?;
+    m.add_class::<PyContext>()?;
     m.add_class::<PyMode>()?;
     m.add_class::<PyKemAlgorithm>()?;
     m.add_class::<PyKdfAlgorithm>()?;


### PR DESCRIPTION
CAPE-815

allows us to do repeated encryption/decryption with an HPKE encryption, like so:
```python
encap, sender_context = hpke.setup_sender(pkR, info)
receiver_context = hpke.setup_receiver(encap, skR, info)
for _ in range(17):
    ctxt = sender_context.seal(aad, ptxt)
    ptxt_onetrip = receiver_context.open(aad, ctxt)
    assert ptxt == ptxt_onetrip
```
also adds support for export contexts via `Hpke.send_export`, `Hpke.receiver_export`, `Hpke.key_schedule`, and `Context.export`